### PR TITLE
Off-Chain Signatures with Multiple Send Contract (STX)

### DIFF
--- a/fiesta_contracts/Clarinet.toml
+++ b/fiesta_contracts/Clarinet.toml
@@ -15,6 +15,11 @@ path = 'contracts/file_comments.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.multi_send_with_off_chain_signatures]
+path = 'contracts/multi_send_with_off_chain_signatures.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.scheduled_withdrawal_wallet]
 path = 'contracts/scheduled_withdrawal_wallet.clar'
 clarity_version = 2

--- a/fiesta_contracts/contracts/multi_send_with_off_chain_signatures.clar
+++ b/fiesta_contracts/contracts/multi_send_with_off_chain_signatures.clar
@@ -1,0 +1,286 @@
+;; Multi-Send with Off-Chain Signatures Contract
+;; Enables gasless multi-send transactions through off-chain signature verification
+
+;; Constants
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant ERR-UNAUTHORIZED (err u100))
+(define-constant ERR-INVALID-SIGNATURE (err u101))
+(define-constant ERR-NONCE-ALREADY-USED (err u102))
+(define-constant ERR-EXPIRED-REQUEST (err u103))
+(define-constant ERR-INVALID-RECIPIENT (err u104))
+(define-constant ERR-INSUFFICIENT-BALANCE (err u105))
+(define-constant ERR-TRANSFER-FAILED (err u106))
+(define-constant ERR-INVALID-RELAYER (err u107))
+
+;; Data Variables
+(define-data-var relayer-fee uint u1000) ;; Fee in microSTX (0.001 STX)
+
+;; Data Maps
+(define-map user-nonces principal uint)
+(define-map authorized-relayers principal bool)
+
+;; Multi-send request structure
+(define-map pending-requests 
+  { user: principal, nonce: uint }
+  {
+    recipients: (list 50 principal),
+    amounts: (list 50 uint),
+    expiry: uint,
+    relayer-fee: uint,
+    signature: (buff 65)
+  }
+)
+
+;; Events
+(define-private (emit-multi-send-event (user principal) (nonce uint) (recipients (list 50 principal)) (amounts (list 50 uint)))
+  (print {
+    event: "multi-send-executed",
+    user: user,
+    nonce: nonce,
+    recipients: recipients,
+    amounts: amounts,
+    block-height: block-height
+  })
+)
+
+;; Private Functions
+
+;; Generate message hash for signature verification
+(define-private (generate-message-hash 
+  (user principal) 
+  (nonce uint) 
+  (recipients (list 50 principal)) 
+  (amounts (list 50 uint)) 
+  (expiry uint)
+  (fee-amount uint))
+  (sha256 (concat
+    (concat
+      (concat
+        (unwrap-panic (to-consensus-buff? user))
+        (unwrap-panic (to-consensus-buff? nonce))
+      )
+      (concat
+        (unwrap-panic (to-consensus-buff? recipients))
+        (unwrap-panic (to-consensus-buff? amounts))
+      )
+    )
+    (concat
+      (unwrap-panic (to-consensus-buff? expiry))
+      (unwrap-panic (to-consensus-buff? fee-amount))
+    )
+  ))
+)
+
+;; Verify off-chain signature
+(define-private (verify-signature 
+  (user principal) 
+  (nonce uint) 
+  (recipients (list 50 principal)) 
+  (amounts (list 50 uint)) 
+  (expiry uint)
+  (fee-amount uint)
+  (signature (buff 65)))
+  (let (
+    (message-hash (generate-message-hash user nonce recipients amounts expiry fee-amount))
+  )
+    ;; Recover the public key from the signature and verify it matches the user
+    (match (secp256k1-recover? message-hash signature)
+      recovered-pubkey 
+        (match (principal-of? recovered-pubkey)
+          recovered-principal (is-eq recovered-principal user)
+          none-case false
+        )
+      error-code false
+    )
+  )
+)
+
+;; Execute individual transfer
+(define-private (execute-transfer (recipient principal) (amount uint))
+  (if (> amount u0)
+    (stx-transfer? amount tx-sender recipient)
+    (ok true)
+  )
+)
+
+;; Process transfers with fold
+(define-private (process-transfer (transfer-data { recipient: principal, amount: uint }) (acc { success: bool, index: uint }))
+  (if (get success acc)
+    (match (execute-transfer (get recipient transfer-data) (get amount transfer-data))
+      success { success: true, index: (+ (get index acc) u1) }
+      error { success: false, index: (get index acc) }
+    )
+    acc
+  )
+)
+
+;; Combine recipients and amounts into transfer data
+(define-private (zip-transfers (recipients (list 50 principal)) (amounts (list 50 uint)))
+  (map combine-transfer-data recipients amounts)
+)
+
+(define-private (combine-transfer-data (recipient principal) (amount uint))
+  { recipient: recipient, amount: amount }
+)
+
+;; Public Functions
+
+;; Submit multi-send request with off-chain signature
+(define-public (submit-multi-send-request
+  (user principal)
+  (nonce uint)
+  (recipients (list 50 principal))
+  (amounts (list 50 uint))
+  (expiry uint)
+  (signature (buff 65)))
+  (let (
+    (current-nonce (default-to u0 (map-get? user-nonces user)))
+    (relayer-fee-amount (var-get relayer-fee))
+  )
+    ;; Verify relayer is authorized
+    (asserts! (default-to false (map-get? authorized-relayers tx-sender)) ERR-INVALID-RELAYER)
+    
+    ;; Verify nonce
+    (asserts! (is-eq nonce (+ current-nonce u1)) ERR-NONCE-ALREADY-USED)
+    
+    ;; Verify not expired
+    (asserts! (> expiry block-height) ERR-EXPIRED-REQUEST)
+    
+    ;; Verify signature
+    (asserts! (verify-signature user nonce recipients amounts expiry relayer-fee-amount signature) ERR-INVALID-SIGNATURE)
+    
+    ;; Verify recipients list is not empty and amounts match
+    (asserts! (is-eq (len recipients) (len amounts)) ERR-INVALID-RECIPIENT)
+    
+    ;; Store the request
+    (map-set pending-requests 
+      { user: user, nonce: nonce }
+      {
+        recipients: recipients,
+        amounts: amounts,
+        expiry: expiry,
+        relayer-fee: relayer-fee-amount,
+        signature: signature
+      }
+    )
+    
+    (ok true)
+  )
+)
+
+;; Execute multi-send transaction
+(define-public (execute-multi-send (user principal) (nonce uint))
+  (let (
+    (request-data (unwrap! (map-get? pending-requests { user: user, nonce: nonce }) ERR-UNAUTHORIZED))
+    (recipients (get recipients request-data))
+    (amounts (get amounts request-data))
+    (expiry (get expiry request-data))
+    (relayer-fee-amount (get relayer-fee request-data))
+    (current-nonce (default-to u0 (map-get? user-nonces user)))
+  )
+    ;; Verify relayer is authorized
+    (asserts! (default-to false (map-get? authorized-relayers tx-sender)) ERR-INVALID-RELAYER)
+    
+    ;; Verify not expired
+    (asserts! (> expiry block-height) ERR-EXPIRED-REQUEST)
+    
+    ;; Verify nonce sequence
+    (asserts! (is-eq nonce (+ current-nonce u1)) ERR-NONCE-ALREADY-USED)
+    
+    ;; Calculate total amount needed
+    (let (
+      (total-amount (fold + amounts u0))
+      (user-balance (stx-get-balance user))
+      (transfer-data (zip-transfers recipients amounts))
+    )
+      ;; Verify user has sufficient balance
+      (asserts! (>= user-balance (+ total-amount relayer-fee-amount)) ERR-INSUFFICIENT-BALANCE)
+      
+      ;; Execute transfers
+      (let (
+        (transfer-result (fold process-transfer transfer-data { success: true, index: u0 }))
+      )
+        (asserts! (get success transfer-result) ERR-TRANSFER-FAILED)
+        
+        ;; Pay relayer fee
+        (try! (as-contract (stx-transfer? relayer-fee-amount user tx-sender)))
+        
+        ;; Update nonce
+        (map-set user-nonces user nonce)
+        
+        ;; Remove processed request
+        (map-delete pending-requests { user: user, nonce: nonce })
+        
+        ;; Emit event
+        (emit-multi-send-event user nonce recipients amounts)
+        
+        (ok true)
+      )
+    )
+  )
+)
+
+;; Admin Functions
+
+;; Add authorized relayer
+(define-public (add-relayer (relayer principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-UNAUTHORIZED)
+    (map-set authorized-relayers relayer true)
+    (ok true)
+  )
+)
+
+;; Remove authorized relayer
+(define-public (remove-relayer (relayer principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-UNAUTHORIZED)
+    (map-delete authorized-relayers relayer)
+    (ok true)
+  )
+)
+
+;; Update relayer fee
+(define-public (set-relayer-fee (new-fee uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-UNAUTHORIZED)
+    (var-set relayer-fee new-fee)
+    (ok true)
+  )
+)
+
+;; Read-only Functions
+
+;; Get user nonce
+(define-read-only (get-user-nonce (user principal))
+  (default-to u0 (map-get? user-nonces user))
+)
+
+;; Check if relayer is authorized
+(define-read-only (is-authorized-relayer (relayer principal))
+  (default-to false (map-get? authorized-relayers relayer))
+)
+
+;; Get relayer fee
+(define-read-only (get-relayer-fee)
+  (var-get relayer-fee)
+)
+
+;; Get pending request
+(define-read-only (get-pending-request (user principal) (nonce uint))
+  (map-get? pending-requests { user: user, nonce: nonce })
+)
+
+;; Generate message hash for off-chain signing
+(define-read-only (get-message-hash-for-signing
+  (user principal) 
+  (nonce uint) 
+  (recipients (list 50 principal)) 
+  (amounts (list 50 uint)) 
+  (expiry uint)
+  (fee-amount uint))
+  (generate-message-hash user nonce recipients amounts expiry fee-amount)
+)
+
+;; Initialize contract with default relayer (contract owner)
+(map-set authorized-relayers CONTRACT-OWNER true)

--- a/fiesta_contracts/tests/multi_send_with_off_chain_signatures.test.ts
+++ b/fiesta_contracts/tests/multi_send_with_off_chain_signatures.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
---

# Multi-Send with Off-Chain Signatures Contract

A Clarity smart contract that enables **gasless multi-send transactions** through **off-chain signatures**. Users can authorize bulk transfers off-chain, and **relayers** execute them on-chain for a small fee.

---

## 🚀 Features

* **Gasless transactions** – Users sign off-chain, relayers pay gas.
* **Bulk transfers** – Send STX to up to **50 recipients in one request**.
* **Nonce tracking** – Prevents replay attacks with sequential nonces.
* **Expiry support** – Transactions expire if not executed before a block height.
* **Relayer system** – Only authorized relayers can submit requests.
* **Relayer fees** – Configurable fee per multi-send to incentivize relayers.
* **Events** – Emits a `multi-send-executed` event after successful execution.

---

## ⚙️ How It Works

1. **User signs off-chain**

   * User prepares a transfer request: recipients, amounts, expiry, and nonce.
   * The request is hashed and signed using their private key.

2. **Relayer submits request**

   * Relayer calls `submit-multi-send-request` with the user’s signed data.
   * Contract verifies:

     * Signature authenticity
     * Nonce order
     * Expiry validity
     * Recipients & amounts match

3. **Relayer executes transfer**

   * Relayer calls `execute-multi-send`.
   * Contract:

     * Transfers STX to all recipients
     * Pays relayer fee
     * Updates nonce
     * Deletes processed request
     * Emits event

---

## 📜 Functions

### 🔹 Public Functions

* `submit-multi-send-request(user, nonce, recipients, amounts, expiry, signature)`
  Store a signed request for future execution by relayer.

* `execute-multi-send(user, nonce)`
  Execute the multi-send transfer after verifying balances, nonce, and expiry.

* `add-relayer(relayer)`
  Add an authorized relayer (only contract owner).

* `remove-relayer(relayer)`
  Remove an authorized relayer (only contract owner).

* `set-relayer-fee(new-fee)`
  Update relayer fee (only contract owner).

---

### 🔹 Read-Only Functions

* `get-user-nonce(user)` → `uint`
* `is-authorized-relayer(relayer)` → `bool`
* `get-relayer-fee()` → `uint`
* `get-pending-request(user, nonce)` → `optional { recipients, amounts, expiry, relayer-fee, signature }`
* `get-message-hash-for-signing(user, nonce, recipients, amounts, expiry, fee-amount)` → `buff`

---

### 🔹 Events

* `multi-send-executed`

  ```clarity
  {
    event: "multi-send-executed",
    user: principal,
    nonce: uint,
    recipients: (list 50 principal),
    amounts: (list 50 uint),
    block-height: uint
  }
  ```

---

## 🛡️ Security

* **Replay protection** via sequential nonces.
* **Expiry enforcement** – requests are invalid after block height.
* **Authorized relayers only** – prevents malicious execution.
* **Signature verification** – ensures only the request owner can authorize transfers.

---

## 🔑 Example Workflow

1. **User signs off-chain:**

   * Nonce = 1
   * Recipients = `[A, B, C]`
   * Amounts = `[100, 200, 300]`
   * Expiry = 12000
   * Fee = 1000 µSTX

2. **Relayer submits request:**

   ```clarity
   (contract-call? .multi-send submit-multi-send-request
     user nonce recipients amounts expiry signature)
   ```

3. **Relayer executes request:**

   ```clarity
   (contract-call? .multi-send execute-multi-send user nonce)
   ```

---

## ⚖️ License

This project is licensed under the **MIT License**.

```
MIT License

Copyright (c) 2025 Esther

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.
```

---